### PR TITLE
Feat: Suggestion of Languages if there is typo in language passed in 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.11.1
+colorama==0.4.6
+soupsieve==2.3.2.post1

--- a/src/creategitignore.py
+++ b/src/creategitignore.py
@@ -3,6 +3,7 @@ import argparse
 
 from colorama import Fore
 from colorama import Style
+import utils
 
 # print(f"{Fore.RED}Error{Style.RESET_ALL} This is {Fore.GREEN}{name}{Style.RESET_ALL}!")
 def create_gitignore(language):
@@ -16,8 +17,13 @@ def create_gitignore(language):
             f.write(text)
         print(f"{Fore.GREEN}Success!:  .gitignore file created{Style.RESET_ALL}")
 
-    except :
-        print(f"{Fore.RED}Error!: try again.{Style.RESET_ALL} \n.gitignore file for {Fore.RED}{language}{Style.RESET_ALL} not found. \nYou are not connected to the internet or the language you entered is not supported yet. \nCheck out {Fore.GREEN}https://github.com/github/gitignore{Style.RESET_ALL} for list of available languages.")
+    except:
+        if utils.check_typo(language):
+            print(f"Did you mean:")
+            for language in utils.get_most_similar_languages(language):
+                print(f"\t{language}")
+        else:
+            print(f"{Fore.RED}Error!: try again.{Style.RESET_ALL} \n.gitignore file for {Fore.RED}{language}{Style.RESET_ALL} not found. \nYou are not connected to the internet or the language you entered is not supported yet. \nCheck out {Fore.GREEN}https://github.com/github/gitignore{Style.RESET_ALL} for list of available languages.")
             
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,28 @@
+from urllib import request
+from bs4 import BeautifulSoup
+import re
+import difflib
+
+# URL on the Github where the csv files are stored
+gitignore_url = 'https://github.com/github/gitignore'
+
+result = request.urlopen(gitignore_url)
+data = result.read()
+text = data.decode("utf-8")
+soup = BeautifulSoup(text, 'html.parser')
+gitignorefiles = soup.find_all(class_="Link--primary",title=re.compile("\.gitignore$"))
+
+filenames = [ ]
+for i in gitignorefiles:
+        filenames.append(i.extract().get_text())
+# print(filenames)
+
+known_languages = [filename.split(".")[0] for filename in filenames]
+# print(known_languages)
+def check_typo(language):
+    """ check if there is a word similar to language """
+    return len(difflib.get_close_matches(language, known_languages)) > 0
+
+def get_most_similar_languages(language, limit=3):
+    """ get languages similar to the language passed in """
+    return difflib.get_close_matches(language, known_languages, limit)


### PR DESCRIPTION
Hello @dapoadedire!

Nice work!

You know what happens when you mistakenly type 
```bash
git sta
```
**instead** of

```
git status
```

This PR adds the same functionality to this package. 

If a user enters a "pythonp" there is a high chance that the user meant "python". So instead of saying the language isn't available user gets a list of languages that closely match the typo.

## How
I scraped the gitignore repo to get all the gitignore file names and check the typed language against the list of languages whose ".gitignore" file is available using [difflib](https://docs.python.org/3/library/difflib.html) library.

## Result

![ign](https://user-images.githubusercontent.com/67077455/204875229-668fdfb8-1ff9-40c4-b238-fc6d1502d84d.png)

## Improvement
The list of the filenames can be stored inside a list in the program instead of scraping the github gitignore page everytime or have the response be cached for some time. 

I will prefer the later approach as it ensures the `.gitignore` file creation is in sync with the typo checking. Moreso, sooner or later the cache will expire and new filenames will be fetched. The cache TTL can be set to a long time as the repo does not get updated frequently.

**PS:** Don't mind the typo, I have a test tomorrow. Off to prepare  for test 👋!

